### PR TITLE
make sure executable starts in the root of the project

### DIFF
--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +27,25 @@ import (
 
 // startCLI starts CLI application w/o color output and w/o command-line completer.
 func startCLI(t *testing.T) *gexpect.ExpectSubprocess {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for !strings.HasSuffix(dir, "ccx/insights-operator-cli") { // make sure it's executed from the correct path
+		err := os.Chdir("../")
+		if err != nil {
+			panic(err)
+		}
+		newDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasSuffix(newDir, "ccx/insights-operator-cli") {
+			break
+		}
+	}
+
 	child, err := gexpect.Spawn("./insights-operator-cli --colors=false --completer=false")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Output locally
```
$ go test ./tests -v
=== RUN   TestCheckQuitCommand
--- PASS: TestCheckQuitCommand (0.01s)
    functional_test.go:53: CLI client has been started
    functional_test.go:68: Expected output '> ' has been found
    functional_test.go:82: Command 'quit' has been sent to CLI client
=== RUN   TestCheckVersionCommand
--- PASS: TestCheckVersionCommand (0.00s)
    functional_test.go:53: CLI client has been started
    functional_test.go:68: Expected output '> ' has been found
    functional_test.go:82: Command 'version' has been sent to CLI client
    functional_test.go:68: Expected output 'Insights operator CLI client' has been found
    functional_test.go:68: Expected output 'version' has been found
    functional_test.go:68: Expected output 'compiled' has been found
    functional_test.go:68: Expected output '> ' has been found
    functional_test.go:82: Command 'quit' has been sent to CLI client
PASS
ok      github.com/redhatinsighs/insights-operator-cli/tests    0.013s
```

I had problems running the tests because it tried to execute `insights-operator-cli` from the `tests` directory.
Currently on master branch:
```
$ go test ./tests -v
=== RUN   TestCheckQuitCommand
--- FAIL: TestCheckQuitCommand (0.00s)
    functional_test.go:30: exec: "./insights-operator-cli": stat ./insights-operator-cli: no such file or directory
=== RUN   TestCheckVersionCommand
--- FAIL: TestCheckVersionCommand (0.00s)
    functional_test.go:30: exec: "./insights-operator-cli": stat ./insights-operator-cli: no such file or directory
FAIL
FAIL    github.com/redhatinsighs/insights-operator-cli/tests    0.001s
```