### PR TITLE
added TestAddClusterCommand

### DIFF
--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -109,4 +111,23 @@ func TestListClustersCommand(t *testing.T) {
 	defer quitCLI(t, child)
 	sendCommand(t, child, "list clusters")
 	expectOutput(t, child, "List of clusters")
+}
+
+func TestAddClusterCommand(t *testing.T) {
+	child := startCLI(t)
+	defer quitCLI(t, child)
+
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clusterName := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+
+	command := fmt.Sprintf("add cluster %s", clusterName)
+	sendCommand(t, child, command)
+	expectOutput(t, child, "Controller has been registered")
+
+	sendCommand(t, child, "list clusters")
+	expectOutput(t, child, clusterName)
 }


### PR DESCRIPTION
The test **fails** because provided clusterID is not used. Instead, it only gets incremented by 1, no matter what number is provided

```
> list clusters
List of clusters
   #   ID Name
   0   11 fw0GEVCkhz
   1   12 CFCxdn66vf
   2   13 LqDxUOm4fJ
   3   14 hNYI56SScu
   4   15 NwqGPonapW
   5   16 new
   6   17 LQ9Yp32t26
   7   18 WwJ9cERPM4
   8   19 TF1eH0BUJL
   9   20 nnqbUIJnL7
  10   21 sXy8C9fbok
  11   22 YTLXtGPlhW
  12   23 6YBrDNyupr
  13   24 FbP5s2moet
  14   25 svMtzB2STY
  15   26 Dxv8M3YWfc
  16   27 XV42DbFauB
```
```
> add cluster 300 cluster
Controller has been registered
```
```
> list clusters
List of clusters
   #   ID Name
   0   11 fw0GEVCkhz
   1   12 CFCxdn66vf
   2   13 LqDxUOm4fJ
   3   14 hNYI56SScu
   4   15 NwqGPonapW
   5   16 new
   6   17 LQ9Yp32t26
   7   18 WwJ9cERPM4
   8   19 TF1eH0BUJL
   9   20 nnqbUIJnL7
  10   21 sXy8C9fbok
  11   22 YTLXtGPlhW
  12   23 6YBrDNyupr
  13   24 FbP5s2moet
  14   25 svMtzB2STY
  15   26 Dxv8M3YWfc
  16   27 XV42DbFauB
  17   28 cluster
```