### PR TITLE
added more commands to test quit

### DIFF
--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -87,11 +87,17 @@ func sendCommand(t *testing.T, child *gexpect.ExpectSubprocess, command string) 
 	t.Log("Command '" + command + "' has been sent to CLI client")
 }
 
-// TestCheckQuitCommand check whether the client can be started and stopped using the 'quit' command.
+// TestCheckQuitCommand check whether the client can be started and stopped using the 'quit', 'exit' or 'bye' command.
 func TestCheckQuitCommand(t *testing.T) {
-	child := startCLI(t)
-	sendCommand(t, child, "quit")
-	child.Wait()
+	commands := []string{
+		"quit", "exit", "bye",
+	}
+
+	for _, command := range commands {
+		child := startCLI(t)
+		sendCommand(t, child, command)
+		child.Wait()
+	}
 }
 
 // TestCheckVersionCommand check the 'version' command.


### PR DESCRIPTION
output locally

```
$ go test ./tests -v -run TestCheckQuitCommand
=== RUN   TestCheckQuitCommand
--- PASS: TestCheckQuitCommand (0.01s)
    functional_test.go:55: CLI client has been started
    functional_test.go:73: Expected output '> ' has been found
    functional_test.go:87: Command 'quit' has been sent to CLI client
    functional_test.go:55: CLI client has been started
    functional_test.go:73: Expected output '> ' has been found
    functional_test.go:87: Command 'exit' has been sent to CLI client
    functional_test.go:55: CLI client has been started
    functional_test.go:73: Expected output '> ' has been found
    functional_test.go:87: Command 'bye' has been sent to CLI client
PASS
ok      github.com/redhatinsighs/insights-operator-cli/tests    0.017s
```