### PR TITLE
Run functional tests with race option

### DIFF
--- a/functional_tests.sh
+++ b/functional_tests.sh
@@ -1,4 +1,4 @@
-go build
+go build -race
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
In order to be able to detect race conditions, we should enable `-race` for tests