### PR TITLE
Fix issue 81

### DIFF
--- a/commands/profiles.go
+++ b/commands/profiles.go
@@ -53,10 +53,17 @@ func DescribeProfile(api restapi.API, profileID string) {
 	fmt.Println(profile.Configuration)
 }
 
+// DeleteConfigurationProfileNoConfirm deletes the profile selected by its ID w/o asking for confirmation
+func DeleteConfigurationProfileNoConfirm(api restapi.API, profileID string) {
+	DeleteConfigurationProfile(api, profileID, false)
+}
+
 // DeleteConfigurationProfile deletes the profile selected by its ID
-func DeleteConfigurationProfile(api restapi.API, profileID string) {
-	if !ProceedQuestion("All configurations based on this profile will be deleted") {
-		return
+func DeleteConfigurationProfile(api restapi.API, profileID string, askForConfirmation bool) {
+	if askForConfirmation {
+		if !ProceedQuestion("All configurations based on this profile will be deleted") {
+			return
+		}
 	}
 
 	err := api.DeleteConfigurationProfile(profileID)
@@ -67,7 +74,7 @@ func DeleteConfigurationProfile(api restapi.API, profileID string) {
 	}
 
 	// everything's ok, configuration profile has been deleted
-	fmt.Println(colorizer.Blue("Configuration profile "+profileID+" has been "), colorizer.Red("deleted"))
+	fmt.Println(colorizer.Blue("Configuration profile "+profileID+" has been"), colorizer.Red("deleted"))
 }
 
 // AddConfigurationProfile adds the profile to database

--- a/commands/profiles_test.go
+++ b/commands/profiles_test.go
@@ -15,3 +15,70 @@ limitations under the License.
 */
 
 package commands_test
+
+import (
+	"github.com/redhatinsighs/insights-operator-cli/commands"
+	"github.com/tisnik/go-capture"
+	"strings"
+	"testing"
+)
+
+// TestDeleteConfigurationProfile checks the command 'delete profile' when no error is reported by REST API
+func TestDeleteConfigurationProfile(t *testing.T) {
+	configureColorizer()
+	restAPIMock := RestAPIMock{}
+
+	captured, err := capture.StandardOutput(func() {
+		commands.DeleteConfigurationProfile(restAPIMock, "0", false)
+	})
+
+	checkCapturedOutput(t, captured, err)
+	if !strings.HasPrefix(captured, "Configuration profile 0 has been deleted") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+}
+
+// TestDeleteConfigurationProfile checks the command 'delete profile' when error is reported by REST API
+func TestDeleteConfigurationProfileErrorHandling(t *testing.T) {
+	configureColorizer()
+	restAPIMock := RestAPIMockErrors{}
+
+	captured, err := capture.StandardOutput(func() {
+		commands.DeleteConfigurationProfile(restAPIMock, "0", false)
+	})
+
+	checkCapturedOutput(t, captured, err)
+	if !strings.HasPrefix(captured, "Error communicating with the service") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+}
+
+// TestDeleteConfigurationProfileNoConfirm checks the command 'delete profile' when no error is reported by REST API
+func TestDeleteConfigurationProfileNoConfirm(t *testing.T) {
+	configureColorizer()
+	restAPIMock := RestAPIMock{}
+
+	captured, err := capture.StandardOutput(func() {
+		commands.DeleteConfigurationProfileNoConfirm(restAPIMock, "0")
+	})
+
+	checkCapturedOutput(t, captured, err)
+	if !strings.HasPrefix(captured, "Configuration profile 0 has been deleted") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+}
+
+// TestDeleteConfigurationProfileNoConfirm checks the command 'delete profile' when error is reported by REST API
+func TestDeleteConfigurationProfileNoConfirmErrorHandling(t *testing.T) {
+	configureColorizer()
+	restAPIMock := RestAPIMockErrors{}
+
+	captured, err := capture.StandardOutput(func() {
+		commands.DeleteConfigurationProfileNoConfirm(restAPIMock, "0")
+	})
+
+	checkCapturedOutput(t, captured, err)
+	if !strings.HasPrefix(captured, "Error communicating with the service") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+}

--- a/ioc.go
+++ b/ioc.go
@@ -79,6 +79,7 @@ var commandsWithParam = []commandWithParam{
 	{"disable configuration ", commands.DisableClusterConfiguration},
 	{"list configurations ", commands.ListOfConfigurations},
 	{"delete cluster ", commands.DeleteClusterNoConfirm},
+	{"delete profile ", commands.DeleteConfigurationProfileNoConfirm},
 	{"delete configuration ", commands.DeleteClusterConfiguration},
 	{"delete trigger ", commands.DeleteTrigger},
 	{"activate must-gather ", commands.ActivateTrigger},
@@ -193,7 +194,7 @@ func executeFixedCommand(t string) {
 		commands.DeleteClusterConfiguration(api, configuration)
 	case "delete profile":
 		profile := prompt.Input("profile: ", commands.LoginCompleter)
-		commands.DeleteConfigurationProfile(api, profile)
+		commands.DeleteConfigurationProfile(api, profile, *askForConfirmation)
 	case "delete trigger":
 		trigger := prompt.Input("trigger: ", commands.LoginCompleter)
 		commands.DeleteTrigger(api, trigger)


### PR DESCRIPTION
# Description

Refactoring implementation of command 'delete profile' so it is possible to call it w/o confirmation.

Fixes #81 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (refactoring code, removing useless files)

## Testing steps
This change is backed by new unit tests, so `./test.sh` is all what's needed ATM.