### PR TITLE
Configuration file read check

### DIFF
--- a/commands/configurations.go
+++ b/commands/configurations.go
@@ -152,6 +152,7 @@ func AddClusterConfigurationImpl(api restapi.API, username string, cluster strin
 	if err != nil {
 		fmt.Println(colorizer.Red("Cannot read configuration file"))
 		fmt.Println(err)
+		return
 	}
 
 	err = api.AddClusterConfiguration(username, cluster, reason, description, configuration)

--- a/commands/configurations_test.go
+++ b/commands/configurations_test.go
@@ -253,3 +253,26 @@ func TestAddClusterConfigurationImplError(t *testing.T) {
 		t.Fatal("Unexpected output:\n", captured)
 	}
 }
+
+// TestAddClusterConfigurationImplBadConfiguration checks the command 'add configuration' for non-existing configuration file
+func TestAddClusterConfigurationImplBadConfiguration(t *testing.T) {
+	configureColorizer()
+	restAPIMock := RestAPIMock{}
+
+	captured, err := capture.StandardOutput(func() {
+		os.Chdir("../")
+		commands.AddClusterConfigurationImpl(restAPIMock, "tester", "cluster0", "reason", "description", "strange_configuration1.json")
+		os.Chdir("./commands")
+	})
+
+	checkCapturedOutput(t, captured, err)
+	if !strings.Contains(captured, "Cannot read configuration file") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+	if !strings.Contains(captured, "no such file or directory") {
+		t.Fatal("Unexpected output:\n", captured)
+	}
+	if strings.Contains(captured, "Configuration has been created") {
+		t.Fatal("Configuration should not be created when configuration file does not exist")
+	}
+}

--- a/commands/rest_api_mock_test.go
+++ b/commands/rest_api_mock_test.go
@@ -165,7 +165,7 @@ func (api RestAPIMock) ReadConfigurationProfile(profileID string) (*types.Config
 	if profileID == "0" {
 		profile := types.ConfigurationProfile{
 			ID:            0,
-			Configuration: "",
+			Configuration: "*configuration*",
 			ChangedAt:     "2020-01-01T00:00:00",
 			ChangedBy:     "tester",
 			Description:   "empty configuration"}


### PR DESCRIPTION
# Description

Configuration is not stored when the file containing configuration can't be read for any reason.

Fixes #84

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing steps
New unit tests are provided, so please use `./test.sh`