### PR TITLE
Profiles unit tests

### DIFF
--- a/commands/clusters_test.go
+++ b/commands/clusters_test.go
@@ -66,7 +66,7 @@ func TestListOfClusters(t *testing.T) {
 	}
 }
 
-// TestListOfClusters checks whether the empty list of clusters read via REST API is displayed correctly
+// TestListOfClustersNoClusters checks whether the empty list of clusters read via REST API is displayed correctly
 func TestListOfClustersNoClusters(t *testing.T) {
 	configureColorizer()
 	restAPIMock := RestAPIMockEmpty{}

--- a/commands/profiles.go
+++ b/commands/profiles.go
@@ -117,6 +117,26 @@ func AddConfigurationProfile(api restapi.API, username string) {
 		return
 	}
 
+	// everything's ok, configuration profile can be created
+	AddConfigurationProfileImpl(api, username, description, configurationFileName)
+}
+
+// AddConfigurationProfileImpl adds the profile to database
+func AddConfigurationProfileImpl(api restapi.API, username string, description string, configurationFileName string) {
+	// TODO: make the directory fully configurable
+	configuration, err := ioutil.ReadFile("configurations/" + configurationFileName)
+	if err != nil {
+		fmt.Println(colorizer.Red("Cannot read configuration file"))
+		fmt.Println(err)
+	}
+
+	err = api.AddConfigurationProfile(username, description, configuration)
+	if err != nil {
+		fmt.Println(colorizer.Red("Error communicating with the service"))
+		fmt.Println(err)
+		return
+	}
+
 	// everything's ok, configuration profile has been created
 	fmt.Println(colorizer.Blue("Configuration profile has been created"))
 }

--- a/commands/rest_api_mock_test.go
+++ b/commands/rest_api_mock_test.go
@@ -48,9 +48,9 @@ func (api RestAPIMock) ReadListOfTriggers() ([]types.Trigger, error) {
 			Cluster:     "ffffffff-ffff-ffff-ffff-ffffffffffff",
 			Reason:      "we need to run must-gather",
 			Link:        "https://www.webpagetest.org/",
-			TriggeredAt: "2020-01-01",
+			TriggeredAt: "2020-01-01T00:00:00",
 			TriggeredBy: "tester",
-			AckedAt:     "1970-01-01",
+			AckedAt:     "1970-01-01T00:00:00",
 			Parameters:  "",
 			Active:      1},
 		types.Trigger{
@@ -59,9 +59,9 @@ func (api RestAPIMock) ReadListOfTriggers() ([]types.Trigger, error) {
 			Cluster:     "ffffffff-ffff-ffff-ffff-ffffffffffff",
 			Reason:      "we need to run must-gather",
 			Link:        "https://www.webpagetest.org/",
-			TriggeredAt: "2020-01-01",
+			TriggeredAt: "2020-01-01T00:00:00",
 			TriggeredBy: "tester",
-			AckedAt:     "2020-01-01",
+			AckedAt:     "2020-01-01T00:00:00",
 			Parameters:  "",
 			Active:      0},
 		types.Trigger{
@@ -70,9 +70,9 @@ func (api RestAPIMock) ReadListOfTriggers() ([]types.Trigger, error) {
 			Cluster:     "00000000-0000-0000-0000-000000000000",
 			Reason:      "we need to run must-gather",
 			Link:        "https://www.webpagetest.org/",
-			TriggeredAt: "2020-01-01",
+			TriggeredAt: "2020-01-01T00:00:00",
 			TriggeredBy: "tester",
-			AckedAt:     "1970-01-01",
+			AckedAt:     "1970-01-01T00:00:00",
 			Parameters:  "",
 			Active:      1},
 		types.Trigger{
@@ -81,9 +81,9 @@ func (api RestAPIMock) ReadListOfTriggers() ([]types.Trigger, error) {
 			Cluster:     "00000000-0000-0000-0000-000000000000",
 			Reason:      "we need to run must-gather",
 			Link:        "https://www.webpagetest.org/",
-			TriggeredAt: "2020-01-01",
+			TriggeredAt: "2020-01-01T00:00:00",
 			TriggeredBy: "tester",
-			AckedAt:     "2020-01-01",
+			AckedAt:     "2020-01-01T00:00:00",
 			Parameters:  "",
 			Active:      0},
 	}
@@ -99,9 +99,9 @@ func (api RestAPIMock) ReadTriggerByID(triggerID string) (*types.Trigger, error)
 			Cluster:     "ffffffff-ffff-ffff-ffff-ffffffffffff",
 			Reason:      "we need to run must-gather",
 			Link:        "https://www.webpagetest.org/",
-			TriggeredAt: "2020-01-01",
+			TriggeredAt: "2020-01-01T00:00:00",
 			TriggeredBy: "tester",
-			AckedAt:     "1970-01-01",
+			AckedAt:     "1970-01-01T00:00:00",
 			Parameters:  "",
 			Active:      1}
 		return &trigger, nil
@@ -116,13 +116,13 @@ func (api RestAPIMock) ReadListOfConfigurationProfiles() ([]types.ConfigurationP
 		types.ConfigurationProfile{
 			ID:            0,
 			Configuration: "",
-			ChangedAt:     "2020-01-01",
+			ChangedAt:     "2020-01-01T00:00:00",
 			ChangedBy:     "tester",
 			Description:   "default configuration profile"},
 		types.ConfigurationProfile{
 			ID:            1,
 			Configuration: "",
-			ChangedAt:     "2020-01-01",
+			ChangedAt:     "2020-01-01T00:00:00",
 			ChangedBy:     "tester",
 			Description:   "another configuration profile"},
 	}


### PR DESCRIPTION
# Description

Unit tests for configuration profiles commands + bunch of other fixes.

Fixes #86

## Type of change

Please delete options that are not relevant.

- [x] Refactor (refactoring code, removing useless files)
- [x] Unit tests

## Testing steps
Updated code is covered by unit tests, so `./test.sh` is all what's needed ATM.
