### PR TITLE
Don't use hardcoded color control chars in abcgo.sh

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,25 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+threshold=75
+
+BLUE=$(tput setaf 4)
+RED_BG=$(tput setab 1)
+GREEN_BG=$(tput setab 2)
+NC=$(tput sgr0) # No Color
 
 go get -u github.com/droptheplot/abcgo
 
 echo -e "${BLUE}ABC metric${NC}"
 abcgo -path .
 
-threshold=75
 echo -e "${BLUE}Functions with ABC metrics greater than ${threshold}${NC}:"
 
 if [[ $(abcgo -path . -sort -format raw | awk "\$4>${threshold}" | tee /dev/tty | wc -l) -ne 0 ]]
 then
-    echo -e "${RED}Functions with too high ABC metrics detected!${NC}"
+    echo -e "${RED_BG}[FAIL]${NC} Functions with too high ABC metrics detected!"
     exit 1
 else
-    echo -e "${GREEN}ABC metrics is ok for all functions in all packages${NC}"
+    echo -e "${GREEN_BG}[OK]${NC} ABC metrics are ok for all functions in all packages"
     exit 0
 fi
 


### PR DESCRIPTION
# Description

Don't use hardcoded color control chars in abcgo.sh

Fixes #162 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
