### PR TITLE
Fix issue #284

### DIFF
--- a/commands/copyright.go
+++ b/commands/copyright.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package commands
 
+// Generated documentation is available at:
+// https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/copyright.html
+
 import (
 	"fmt"
 )

--- a/docs/packages/commands/copyright.html
+++ b/docs/packages/commands/copyright.html
@@ -119,6 +119,17 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">commands</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Generated documentation is available at:
+https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands</p>
+
+<p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/commands/copyright.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;fmt&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/copyright.go`

Fixes #284

## Type of change

- Documentation update

## Testing steps

N/A