### PR TITLE
Fix issue 297

### DIFF
--- a/commands/rest_api_mock_empty_test.go
+++ b/commands/rest_api_mock_empty_test.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/rest_api_mock_empty_test.html
+
 package commands_test
 
 import (

--- a/docs/packages/commands/rest_api_mock_empty_test.html
+++ b/docs/packages/commands/rest_api_mock_empty_test.html
@@ -117,6 +117,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */</div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/commands/rest<em>api</em>mock<em>empty</em>test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">package</div> <div class="ident">commands_test</div><div class="operator"></div>
 
 <div class="keyword">import</div> <div class="operator">(</div>


### PR DESCRIPTION
# Description

Add link to documentation generated for redhatinsights/insights-operator-cli/commands/rest_api_mock_empty_test.go

Fixes #297

## Type of change

- Documentation update

## Testing steps

N/A