### PR TITLE
Links in comments should be placed after `package` clausule

### DIFF
--- a/commands/authors_test.go
+++ b/commands/authors_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/authors_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/clusters_test.go
+++ b/commands/clusters_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/clusters_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/configurations_test.go
+++ b/commands/configurations_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/configurations_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/copyright_test.go
+++ b/commands/copyright_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/copyright_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/help_test.go
+++ b/commands/help_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/help_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/license_test.go
+++ b/commands/license_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/license_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/profiles_test.go
+++ b/commands/profiles_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/profiles_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/commands/rest_api_mock_empty_test.go
+++ b/commands/rest_api_mock_empty_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/rest_api_mock_empty_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/types"

--- a/commands/rest_api_mock_errors_test.go
+++ b/commands/rest_api_mock_errors_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/rest_api_mock_errors_test.html
-
-package commands_test
 
 import (
 	"errors"

--- a/commands/rest_api_mock_test.go
+++ b/commands/rest_api_mock_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/rest_api_mock_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/types"

--- a/commands/triggers_test.go
+++ b/commands/triggers_test.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+package commands_test
+
 // Documentation in literate-programming-style is available at:
 // https://redhatinsights.github.io/insights-operator-cli/packages/commands/commands_test.html
-
-package commands_test
 
 import (
 	"github.com/redhatinsighs/insights-operator-cli/commands"


### PR DESCRIPTION
# Description

Links in comments should be placed after `package` clausule

Fixes #493

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A