### PR TITLE
Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/profiles.go`

### DIFF
--- a/commands/profiles.go
+++ b/commands/profiles.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package commands
 
+// Generated documentation is available at:
+// https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/profiles.html
+
 import (
 	"fmt"
 	"github.com/c-bata/go-prompt"

--- a/docs/packages/commands/profiles.html
+++ b/docs/packages/commands/profiles.html
@@ -119,6 +119,17 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">commands</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Generated documentation is available at:
+https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands</p>
+
+<p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/commands/profiles.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;fmt&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/c-bata/go-prompt&#34;</div><div class="operator"></div>


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/profiles.go`

Fixes #295

## Type of change

- Documentation update

## Testing steps

N/A