### PR TITLE
Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/commands.go`

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -45,3 +45,9 @@ limitations under the License.
 //
 // * triggers.go
 package commands
+
+// Generated documentation is available at:
+// https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/commands.html

--- a/docs/packages/commands/commands.html
+++ b/docs/packages/commands/commands.html
@@ -159,6 +159,17 @@ source files:</p>
 </code></pre></td>
       </tr>
       
+      <tr class="section">
+	<td class="doc"><p>Generated documentation is available at:
+https://godoc.org/github.com/RedHatInsights/insights-operator-cli/commands</p>
+
+<p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/commands/commands.html</p>
+</td>
+	<td class="code"><pre><code>
+</code></pre></td>
+      </tr>
+      
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/commands.go`

Fixes #281

## Type of change

- Documentation update

## Testing steps

N/A