### PR TITLE
 Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/common_test.go`

### DIFF
--- a/commands/common_test.go
+++ b/commands/common_test.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package commands_test
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/common_test.html
+
 import (
 	"github.com/logrusorgru/aurora"
 	"github.com/redhatinsighs/insights-operator-cli/commands"

--- a/docs/packages/commands/common_test.html
+++ b/docs/packages/commands/common_test.html
@@ -119,6 +119,14 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">commands_test</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/commands/common_test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;github.com/logrusorgru/aurora&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/redhatinsighs/insights-operator-cli/commands&#34;</div><div class="operator"></div>


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/common_test.go`

Fixes #288

## Type of change

- Documentation update

## Testing steps

N/A