### PR TITLE
Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/commands_test.go`

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -42,3 +42,6 @@ limitations under the License.
 //
 // * triggers_test.go
 package commands_test
+
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/commands/commands.html


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/commands/commands_test.go`

Fixes #286

## Type of change

- Documentation update

## Testing steps

N/A