### PR TITLE
Add link to documentation generated for `redhatinsights/insights-operator-cli/ioc.go`

### DIFF
--- a/docs/packages/ioc.html
+++ b/docs/packages/ioc.html
@@ -126,6 +126,17 @@ instrumentation service.</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">main</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Generated documentation is available at:
+https://godoc.org/github.com/RedHatInsights/insights-operator-cli/</p>
+
+<p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/ioc.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;bufio&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;flag&#34;</div><div class="operator"></div>

--- a/ioc.go
+++ b/ioc.go
@@ -18,6 +18,12 @@ limitations under the License.
 // instrumentation service.
 package main
 
+// Generated documentation is available at:
+// https://godoc.org/github.com/RedHatInsights/insights-operator-cli/
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/ioc.html
+
 import (
 	"bufio"
 	"flag"


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/ioc.go`

Fixes #275

## Type of change

- Documentation update

## Testing steps

N/A