### PR TITLE
Add link to documentation `generated for redhatinsights/insights-operator-cli/ioc_test.go`

### DIFF
--- a/docs/packages/ioc_test.html
+++ b/docs/packages/ioc_test.html
@@ -118,6 +118,14 @@ limitations under the License.
 */</div>
 <div class="keyword">package</div> <div class="ident">main_test</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/ioc_test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;github.com/c-bata/go-prompt&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/logrusorgru/aurora&#34;</div><div class="operator"></div>

--- a/ioc_test.go
+++ b/ioc_test.go
@@ -15,6 +15,9 @@ limitations under the License.
 */
 package main_test
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/ioc_test.html
+
 import (
 	"github.com/c-bata/go-prompt"
 	"github.com/logrusorgru/aurora"


### PR DESCRIPTION
# Description

Add link to documentation `generated for redhatinsights/insights-operator-cli/ioc_test.go`

Fixes #276

## Type of change

- Documentation update

## Testing steps

N/A