### PR TITLE
Add link to documentation generated for `redhatinsights/insights-operator-cli/export_test.go`

### DIFF
--- a/docs/packages/export_test.html
+++ b/docs/packages/export_test.html
@@ -123,6 +123,14 @@ limitations under the License.
       </tr>
       
       <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/export_test.html</p>
+</td>
+	<td class="code"><pre><code>
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
 	<td class="doc"><p>Export for testing</p>
 
 <p>This source file contains name aliases of all package-private functions

--- a/export_test.go
+++ b/export_test.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package main
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/export_test.html
+
 // Export for testing
 //
 // This source file contains name aliases of all package-private functions


### PR DESCRIPTION
# Description

Add link to documentation generated for `redhatinsights/insights-operator-cli/export_test.go`

Fixes #274

## Type of change

- Documentation update

## Testing steps

N/A