### PR TITLE
Fix issue #358

### DIFF
--- a/docs/packages/types/configuration_profile_test.html
+++ b/docs/packages/types/configuration_profile_test.html
@@ -123,6 +123,14 @@ limitations under the License.
       </tr>
       
       <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/types/configuration<em>profile</em>test.html</p>
+</td>
+	<td class="code"><pre><code>
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
 	<td class="doc"><p>Please note that currently the &quot;types&quot; package contains just declaration of
 new data types w/o any other code. So there's no need to create unit tests.</p>
 </td>

--- a/types/configuration_profile_test.go
+++ b/types/configuration_profile_test.go
@@ -16,5 +16,8 @@ limitations under the License.
 
 package types_test
 
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/types/configuration_profile_test.html
+
 // Please note that currently the "types" package contains just declaration of
 // new data types w/o any other code. So there's no need to create unit tests.


### PR DESCRIPTION
# Description

Add link to documentation generated for `types/configuration_profile_test.go`

Fixes #358

## Type of change

- Documentation update

## Testing steps

N/A