### PR TITLE
Fixes: the following string occured many times in sources: "Unable to read response body"

### DIFF
--- a/docs/packages/restapi/utils.html
+++ b/docs/packages/restapi/utils.html
@@ -131,6 +131,7 @@ limitations under the License.
 
 <div class="keyword">const</div> <div class="operator">(</div>
 	<div class="ident">communicationErrorWithServerErrorMessage</div> <div class="operator">=</div> <div class="literal">&#34;Communication error with the server %v&#34;</div><div class="operator"></div>
+	<div class="ident">unableToReadResponseBodyError</div>            <div class="operator">=</div> <div class="literal">&#34;Unable to read response body&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>
 
 </code></pre></td>
@@ -160,7 +161,7 @@ method and if the call is successful read the body of response.</p>
 	<div class="keyword">defer</div> <div class="ident">closeResponseBody</div><div class="operator">(</div><div class="ident">response</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">readErr</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="keyword">return</div> <div class="ident">nil</div><div class="operator">,</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Errorf</div><div class="operator">(</div><div class="literal">&#34;Unable to read response body&#34;</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">nil</div><div class="operator">,</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Errorf</div><div class="operator">(</div><div class="ident">unableToReadResponseBodyError</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
 	<div class="keyword">return</div> <div class="ident">body</div><div class="operator">,</div> <div class="ident">nil</div><div class="operator"></div>
@@ -193,7 +194,7 @@ of response.</p>
 	<div class="keyword">defer</div> <div class="ident">closeResponseBody</div><div class="operator">(</div><div class="ident">response</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">readErr</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="keyword">return</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Errorf</div><div class="operator">(</div><div class="literal">&#34;Unable to read response body&#34;</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Errorf</div><div class="operator">(</div><div class="ident">unableToReadResponseBodyError</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 	<div class="keyword">return</div> <div class="ident">parseResponse</div><div class="operator">(</div><div class="ident">body</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>

--- a/restapi/utils.go
+++ b/restapi/utils.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	communicationErrorWithServerErrorMessage = "Communication error with the server %v"
+	unableToReadResponseBodyError            = "Unable to read response body"
 )
 
 // performReadRequest function try to perform HTTP request using the HTTP GET
@@ -46,7 +47,7 @@ func performReadRequest(url string) ([]byte, error) {
 	defer closeResponseBody(response)
 
 	if readErr != nil {
-		return nil, fmt.Errorf("Unable to read response body")
+		return nil, fmt.Errorf(unableToReadResponseBodyError)
 	}
 
 	return body, nil
@@ -74,7 +75,7 @@ func performWriteRequest(url string, method string, payload io.Reader) error {
 	defer closeResponseBody(response)
 
 	if readErr != nil {
-		return fmt.Errorf("Unable to read response body")
+		return fmt.Errorf(unableToReadResponseBodyError)
 	}
 	return parseResponse(body)
 }


### PR DESCRIPTION
# Description

Fixes: the following string occured many times in sources: "Unable to read response body"

Fixes #145

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A