### PR TITLE
Added link to generated documentation for `restapi/utils.go`

### DIFF
--- a/docs/packages/restapi/utils.html
+++ b/docs/packages/restapi/utils.html
@@ -119,6 +119,17 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">restapi</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Generated documentation is available at:
+https://godoc.org/github.com/RedHatInsights/insights-operator-cli/restapi</p>
+
+<p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/insights-operator-cli/packages/restapi/utils.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;encoding/json&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;fmt&#34;</div><div class="operator"></div>

--- a/restapi/utils.go
+++ b/restapi/utils.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package restapi
 
+// Generated documentation is available at:
+// https://godoc.org/github.com/RedHatInsights/insights-operator-cli/restapi
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-cli/packages/restapi/utils.html
+
 import (
 	"encoding/json"
 	"fmt"


### PR DESCRIPTION
# Description

Added link to generated documentation for `restapi/utils.go`

Fixes #386

## Type of change

- Documentation update

## Testing steps

N/A