### PR TITLE
Change Go version in CI from 1.14 to 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 
 language: go
 go:
-- 1.14
+- 1.16
 
 jobs:
   include:


### PR DESCRIPTION
# Description

Upgrading used version of Go from 1.14 to 1.16 in Travis CI.

Fixes #454 

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

No testing has been done.

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
